### PR TITLE
Allow Unordered Dimensions for DimsSchema Validation

### DIFF
--- a/src/xarray_validate/components.py
+++ b/src/xarray_validate/components.py
@@ -74,6 +74,7 @@ class DimsSchema(BaseSchema):
             )
         ),
     )
+    ordered: bool = _attrs.field(default=True)
 
     def serialize(self) -> list:
         # Inherit docstring
@@ -92,11 +93,24 @@ class DimsSchema(BaseSchema):
                 f"dimension number mismatch: got {len(dims)}, expected {len(self.dims)}"
             )
 
-        for i, (actual, expected) in enumerate(zip(dims, self.dims)):
-            if expected is not None and actual != expected:
+        if not self.ordered:
+            actual = set(dims)
+            expected = set(self.dims)
+
+            if actual != expected:
                 raise SchemaError(
-                    f"dimension mismatch in axis {i}: got {actual}, expected {expected}"
+                    "dimension mismatch: expected but not received "
+                    f"{expected - actual}, "
+                    f"and not expected but received {actual - expected}"
                 )
+
+        else:
+            for i, (actual, expected) in enumerate(zip(dims, self.dims)):
+                if expected is not None and actual != expected:
+                    raise SchemaError(
+                        f"dimension mismatch in axis {i}: "
+                        f"got {actual}, expected {expected}"
+                    )
 
 
 @_attrs.define(on_setattr=[_attrs.setters.convert, _attrs.setters.validate])


### PR DESCRIPTION
Ref: #5 

## Problem Statement
Xarray supports named dimensions; this is one of the main features of Xarray and it allows users to keep track of dimensions by their names rather than their positions:
```python
arr = np.ones((5, 5))
da = xr.DataArray(arr, dims=["dim0", "dim1"])
da.sel(dim0=3)  # xarray
# instead of
arr[0][3]  # numpy
```
This holds true in Xarray's internal functionalities, such as dot / cross products, where the operations occur along the dimensions of the same name, rather than the lining up the last dimension of the former array to the first dimension of the latter array. In some use cases, this effectively eliminates the need for transposing Xarray DataArrays, i.e. arranging dimensions in a correct order.

As such, it would make sense that in some cases of Xarray usage, users will care less about the order of dimensions, and rather focus on matching the set of the names.

Implementing this without directly manipulating xarray-validate is difficult, since it requires the user to test against all permutations of the dimensions and checking if any of them passes.

## Proposal

The feature proposed here works like below:
```python
arr1 = xr.DataArray(np.ones((5, 5)), dims=('dim0', 'dim1'))
dims_schema = DimsSchema(('dims1', 'dims0'), ordered=False)

dims_schema.validate(arr1)  # returns None

arr1 = xr.DataArray(np.ones((5, 5)), dims=('dim0', 'dim1'))
dims_schema = DimsSchema(('dims1', 'dims0'), ordered=True)  # ordered defaults to True, and thus can be omitted.

dims_schema.validate(arr1)  # SchemaError
```

## Implementation

The implementation details are rather simple:
```python
@_attrs.define(on_setattr=[_attrs.setters.convert, _attrs.setters.validate])
class DimsSchema(BaseSchema):
    ...

# ------- ADDITION ------- #

    ordered: bool = _attrs.field(default=True)

# --------- END ---------- #
    ...

    def validate(self, dims: DimsT) -> None:
        # Inherit docstring

        if len(self.dims) != len(dims):
            raise SchemaError(
                f"dimension number mismatch: got {len(dims)}, expected {len(self.dims)}"
            )

# ------- ADDITION ------- #

        if not self.ordered:
            actual = set(dims)
            expected = set(self.dims)

            if actual != expected:
                raise SchemaError(
                    f"dimension mismatch: expected but not received {expected - actual}, and not expected but received {actual - expected}"
                )

        else:

# --------- END ---------- #

            for i, (actual, expected) in enumerate(zip(dims, self.dims)):
                if expected is not None and actual != expected:
                    raise SchemaError(
                        f"dimension mismatch in axis {i}: got {actual}, expected {expected}"
                    )
```

## Tests

I've added two unit tests, which focuses on `ordered=False` cases. The existing tests need deeper changes to allow negative tests (where the validation fails), so I have not added those yet.